### PR TITLE
Run tests with short flag by default

### DIFF
--- a/lib/tester.js
+++ b/lib/tester.js
@@ -278,6 +278,9 @@ class Tester {
 
         let cmd = go
         let args = ['test', '-coverprofile=' + this.coverageFile]
+        if (atom.config.get('tester-go.runCoverageWithShortFlag')) {
+          args.push('-short')
+        }
         let executorOptions = this.getExecutorOptions(editor)
         return config.executor.exec(cmd, args, executorOptions).then((r) => {
           if (r.stderr && r.stderr.trim() !== '') {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,13 @@
       "type": "boolean",
       "default": false,
       "order": 1
+    },
+    "runCoverageWithShortFlag": {
+      "title": "Run Coverage With Short Flag Set",
+      "description": "Runs `go test` with `-short` flag set",
+      "type": "boolean",
+      "default": true,
+      "order": 2
     }
   },
   "standard": {


### PR DESCRIPTION
IMO, we want to default to `-short` because editor-based tools should (generally) return as rapidly as possible. Long-running tests should be reserved for CI. I'm open to changing the default to `false` if I hold a minority opinion, however.