### PR TITLE
add usage section with shortcuts and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ It depends on the following packages:
 * [`go-config`](https://atom.io/packages/go-config)
 * [`go-get`](https://atom.io/packages/go-get)
 
+## Usage
+
+* Show coverage from the Command Palette with `Golang: gocover` or the shortcut <kbd>ctrl+alt+c</kbd>.
+* Clear coverage with `Golang: Cleargocover` or <kbd>ctrl+alt+shift+c</kbd>.
+
 ## Configuration
 
 * `runCoverageOnSave`: Run `go test -coverprofile` on the current package each


### PR DESCRIPTION
I added `runCoverageOnSave` to my configurations just fine, but I wanted to turn off coverage for Go files I knew didn't, or wouldn't have testing. My instinct was to search for `tester-go` in the Command Palette, and I had to look in to tester-go/keymaps in order to find the shortcuts.

I thought this update to README.md would be helpful to someone in my position. I tried to keep the additions idiomatic to the existing documentation.