### PR TITLE
Fix for relatives/symlinked paths (#8)

### DIFF
--- a/lib/tester.js
+++ b/lib/tester.js
@@ -138,8 +138,9 @@ class Tester {
     if (!this.ranges || this.ranges.length <= 0) {
       return
     }
-
-    let editorRanges = _.filter(this.ranges, (r) => { return _.endsWith(file, r.file) })
+    let editorRanges = _.filter(this.ranges, (r) => {
+      return _.endsWith(file, r.file.replace(/^_\//g, ''))
+    })
 
     if (!editorRanges || editorRanges.length <= 0) {
       return


### PR DESCRIPTION
Got same problem as : https://github.com/joefitzgerald/tester-go/issues/8

When testing symlinked libs like : `$GOPATH/lib1 -> $HOME/src/lib1` the `go test` (and so the coverprofile file) use absolute paths and prefixes them all by `_/` 
Example : 

``` console
$ cd $GOPATH/src/golang.org/x/net/websocket
go test -coverprofile cover && head cover
2016/07/29 14:44:42 Test WebSocket server listening on 127.0.0.1:41415
PASS
coverage: 78.2% of statements
ok      golang.org/x/net/websocket  0.013s
mode: set
golang.org/x/net/websocket/client.go:22.36,24.2 1 0
golang.org/x/net/websocket/client.go:27.67,31.16 4 1
....
```

And  

``` console
$ ls -l $GOPATH/src/foo/bar
lrwxrwxrwx 1 cyberj cyberj 31 juil.  4 08:25 /home/cyberj/src/go/src/foo/bar -> /home/cyberj/custom/dir/
$ cd $GOPATH/src/foo/bar
$ go test -coverprofile cover && head cover
PASS
coverage: 30.4% of statements
ok      _/home/cyberj/custom/dir    0.006s
mode: set
_/home/cyberj/custom/dir/filename.go:44.54,46.15 1 0
_/home/cyberj/custom/dir/filename.go:50.2,50.16 1 0
```

So in your module : 

``` javascript
file="/home/cyberj/custom/dir/filename.go"
r.file="_/home/cyberj/custom/dir/filename.go"
_.endsWith(file, r.file) == false
```

I'm unable to code a test because of a `fs-plus` dependency. Tried to `npm install -g fs-plus` but still.
