### PR TITLE
Add tabs

### DIFF
--- a/lib/components/test-panel.js
+++ b/lib/components/test-panel.js
@@ -1,0 +1,37 @@
+/** @babel */
+/** @jsx etch.dom */
+/* eslint-disable react/no-unknown-property */
+
+import {CompositeDisposable} from 'atom'
+import etch from 'etch'
+import EtchComponent from '../etch-component'
+
+export default class TestPanel extends EtchComponent {
+  constructor (props) {
+    if (!props) {
+      props = {icon: 'check', state: 'unknown', testOutput: 'No test output...'}
+    }
+    super(props)
+    this.subscriptions = new CompositeDisposable()
+  }
+
+  render () {
+    return (
+      <atom-panel className='padded'>
+        <div className='inset-panel'>
+          <div className='panel-heading'>GO TEST <span className='close' /></div>
+          <div className='panel-body padded'><span style='white-space: pre-wrap;'>{this.props.testOutput}</span></div>
+        </div>
+      </atom-panel>
+    )
+  }
+
+  dispose () {
+    this.destroy()
+  }
+
+  destroy () {
+    super.destroy()
+    this.subscriptions.dispose()
+  }
+}

--- a/lib/components/test-panel.js
+++ b/lib/components/test-panel.js
@@ -17,13 +17,21 @@ export default class TestPanel extends EtchComponent {
 
   render () {
     return (
-      <atom-panel className='padded'>
+      <atom-panel className='tester-go-panel padded'>
         <div className='inset-panel'>
-          <div className='panel-heading'>GO TEST</div>
+          <div className='panel-heading'>GO TEST
+            <button className='panel-button icon icon-x' onclick={this.handleClick.bind(this)} />
+          </div>
           <div className='panel-body padded'><span style='white-space: pre-wrap;'>{this.props.testOutput}</span></div>
         </div>
       </atom-panel>
     )
+  }
+
+  handleClick () {
+    if (this.props.toggle) {
+      this.props.toggle()
+    }
   }
 
   dispose () {

--- a/lib/components/test-panel.js
+++ b/lib/components/test-panel.js
@@ -19,7 +19,7 @@ export default class TestPanel extends EtchComponent {
     return (
       <atom-panel className='padded'>
         <div className='inset-panel'>
-          <div className='panel-heading'>GO TEST <span className='close' /></div>
+          <div className='panel-heading'>GO TEST</div>
           <div className='panel-body padded'><span style='white-space: pre-wrap;'>{this.props.testOutput}</span></div>
         </div>
       </atom-panel>

--- a/lib/components/test-panel.js
+++ b/lib/components/test-panel.js
@@ -19,9 +19,14 @@ export default class TestPanel extends EtchComponent {
     return (
       <atom-panel className='tester-go-panel padded'>
         <div className='inset-panel'>
-          <div className='panel-heading'>GO TEST
+          <header className='panel-heading'>
+            <nav className='panel-nav'>
+              <span className='panel-nav-item'>GO</span>
+              <span className='panel-nav-item is-selected'>TEST</span>
+              <span className='panel-nav-item'>BUILD</span>
+            </nav>
             <button className='panel-button icon icon-x' onclick={this.handleClick.bind(this)} />
-          </div>
+          </header>
           <div className='panel-body padded'><span style='white-space: pre-wrap;'>{this.props.testOutput}</span></div>
         </div>
       </atom-panel>

--- a/lib/components/test-status-bar.js
+++ b/lib/components/test-status-bar.js
@@ -1,0 +1,49 @@
+/** @babel */
+/** @jsx etch.dom */
+/* eslint-disable react/no-unknown-property */
+
+import {CompositeDisposable} from 'atom'
+import etch from 'etch'
+import EtchComponent from '../etch-component'
+
+export default class TestStatusBar extends EtchComponent {
+  constructor (props) {
+    if (!props) {
+      props = {icon: 'check', state: 'unknown'}
+    }
+    super(props)
+    this.subscriptions = new CompositeDisposable()
+
+    // this.subscriptions.add(atom.tooltips.add(this.element, {title: 'An update will be installed the next time Atom is relaunched.<br/><br/>Click the squirrel icon for more information.'}))
+  }
+
+  handleClick () {
+    if (this.props.toggle) {
+      this.props.toggle()
+    }
+  }
+
+  render () {
+    if (!this.props.icon) {
+      this.props.icon = 'check'
+    }
+
+    if (!this.props.state) {
+      this.props.state = 'unknown'
+    }
+
+    let className = 'test-status-bar test-status-' + this.props.state + ' icon icon-' + this.props.icon + ' inline-block'
+    return (
+      <span type='button' className={className} onclick={this.handleClick.bind(this)} />
+    )
+  }
+
+  dispose () {
+    this.destroy()
+  }
+
+  destroy () {
+    super.destroy()
+    this.subscriptions.dispose()
+  }
+}

--- a/lib/etch-component.js
+++ b/lib/etch-component.js
@@ -1,0 +1,59 @@
+/** @babel */
+/** @jsx etch.dom */
+
+import etch from 'etch'
+
+/*
+  Public: Abstract class for handling the initialization
+  boilerplate of an Etch component.
+*/
+export default class EtchComponent {
+  constructor (props) {
+    this.props = props
+
+    etch.initialize(this)
+    EtchComponent.setScheduler(atom.views)
+  }
+
+  /*
+    Public: Gets the scheduler Etch uses for coordinating DOM updates.
+
+    Returns a {Scheduler}
+  */
+  static getScheduler () {
+    return etch.getScheduler()
+  }
+
+  /*
+    Public: Sets the scheduler Etch uses for coordinating DOM updates.
+
+    * `scheduler` {Scheduler}
+  */
+  static setScheduler (scheduler) {
+    etch.setScheduler(scheduler)
+  }
+
+  /*
+    Public: Updates the component's properties and re-renders it. Only the
+    properties you specify in this object will update – any other properties
+    the component stores will be unaffected.
+
+    * `props` an {Object} representing the properties you want to update
+  */
+  update (props) {
+    let oldProps = this.props
+    this.props = Object.assign({}, oldProps, props)
+    return etch.update(this)
+  }
+
+  /*
+    Public: Destroys the component, removing it from the DOM.
+  */
+  destroy () {
+    etch.destroy(this)
+  }
+
+  render () {
+    throw new Error('Etch components must implement a `render` method')
+  }
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,13 +2,16 @@
 
 import {CompositeDisposable} from 'atom'
 import {Tester} from './tester'
+import {TestPanelManager} from './test-panel-manager'
 
 export default {
   dependenciesInstalled: null,
   goget: null,
   goconfig: null,
-  tester: null,
+  statusBar: null,
+  statusbartile: null,
   subscriptions: null,
+  tester: null,
   toolCheckComplete: null,
 
   activate () {
@@ -19,6 +22,8 @@ export default {
     }).catch((e) => {
       console.log(e)
     })
+
+    this.getTestPanelManager()
     this.getTester()
   },
 
@@ -29,7 +34,9 @@ export default {
     this.subscriptions = null
     this.goget = null
     this.goconfig = null
+    this.statusBar = null
     this.tester = null
+    this.testPanelManager = null
     this.dependenciesInstalled = null
     this.toolCheckComplete = null
   },
@@ -46,9 +53,22 @@ export default {
       return this.getGoconfig()
     }, () => {
       return this.getGoget()
+    }, () => {
+      return this.getTestPanelManager()
     })
     this.subscriptions.add(this.tester)
     return this.tester
+  },
+
+  getTestPanelManager () {
+    if (this.testPanelManager) {
+      return this.testPanelManager
+    }
+    this.testPanelManager = new TestPanelManager(() => {
+      return this.getStatusBar()
+    })
+    this.subscriptions.add(this.testPanelManager)
+    return this.testPanelManager
   },
 
   getGoconfig () {
@@ -65,6 +85,13 @@ export default {
     return false
   },
 
+  getStatusBar () {
+    if (this.statusBar) {
+      return this.statusBar
+    }
+    return false
+  },
+
   consumeGoconfig (service) {
     this.goconfig = service
     this.checkForTools()
@@ -73,6 +100,11 @@ export default {
   consumeGoget (service) {
     this.goget = service
     this.checkForTools()
+  },
+
+  consumeStatusBar (service) {
+    this.statusBar = service
+    this.testPanelManager.showStatusBar()
   },
 
   checkForTools () {

--- a/lib/test-panel-manager.js
+++ b/lib/test-panel-manager.js
@@ -8,7 +8,7 @@ class TestPanelManager {
   constructor (statusBarFunc) {
     this.statusBar = statusBarFunc
     this.subscriptions = new CompositeDisposable()
-    this.testPanel = new TestPanel()
+    this.testPanel = new TestPanel({toggle: () => this.togglePanel()})
     this.subscriptions.add(this.testPanel)
     this.panelVisible = false
     this.panel = atom.workspace.addBottomPanel({item: this.testPanel, visible: this.panelVisible, priority: 10})

--- a/lib/test-panel-manager.js
+++ b/lib/test-panel-manager.js
@@ -60,11 +60,11 @@ class TestPanelManager {
       icon = 'check'
     }
 
-    if (props.state) {
+    if (props.state && this.testStatusBar) {
       this.testStatusBar.update({state: props.state, icon: icon})
     }
 
-    if (props.output && props.output.length > 0) {
+    if (props.output && props.output.length > 0 && this.testPanel) {
       this.testPanel.update({testOutput: props.output})
     }
 

--- a/lib/test-panel-manager.js
+++ b/lib/test-panel-manager.js
@@ -1,0 +1,108 @@
+'use babel'
+
+import {CompositeDisposable} from 'atom'
+import TestPanel from './components/test-panel'
+import TestStatusBar from './components/test-status-bar'
+
+class TestPanelManager {
+  constructor (statusBarFunc) {
+    this.statusBar = statusBarFunc
+    this.subscriptions = new CompositeDisposable()
+    this.testPanel = new TestPanel()
+    this.subscriptions.add(this.testPanel)
+    this.panelVisible = false
+    this.panel = atom.workspace.addBottomPanel({item: this.testPanel, visible: this.panelVisible, priority: 10})
+    this.subscriptions.add(atom.config.observe('tester-go.displayTestOutputPanel', (displayTestOutputPanel) => {
+      this.displayTestOutputPanel = displayTestOutputPanel
+    }))
+  }
+
+  dispose () {
+    if (this.subscriptions) {
+      this.subscriptions.dispose()
+    }
+    this.subscriptions = null
+    if (this.panel) {
+      this.panel.destroy()
+    }
+    this.panel = null
+    this.testPanel = null
+    this.statusBar = null
+    this.testStatusBar = null
+    if (this.testStatusBarTile) {
+      this.testStatusBarTile.destroy()
+    }
+    this.testStatusBarTile = null
+  }
+
+  togglePanel () {
+    if (!this.panel) {
+      return
+    }
+
+    if (this.panelVisible) {
+      this.panel.hide()
+      this.panelVisible = false
+    } else {
+      this.panel.show()
+      this.panelVisible = true
+    }
+  }
+
+  update (props) {
+    if (!props) {
+      return
+    }
+    let icon = 'light-bulb'
+    if (props.exitcode && props.exitcode !== 0) {
+      icon = 'remove-close'
+    } else if (props.exitcode === 0) {
+      icon = 'check'
+    }
+
+    if (props.state) {
+      this.testStatusBar.update({state: props.state, icon: icon})
+    }
+
+    if (props.output && props.output.length > 0) {
+      this.testPanel.update({testOutput: props.output})
+    }
+
+    if (this.displayTestOutputPanel === 'always') {
+      this.panel.show()
+      this.panelVisible = true
+      return
+    }
+
+    if (props.exitcode && props.exitcode !== 0 && this.displayTestOutputPanel === 'failure-only') {
+      this.panel.show()
+      this.panelVisible = true
+      return
+    }
+
+    if (props.exitcode === 0 && this.displayTestOutputPanel === 'success-only') {
+      this.panel.show()
+      this.panelVisible = true
+      return
+    }
+  }
+
+  showStatusBar () {
+    if (this.testStatusBar || !this.statusBar()) {
+      return
+    }
+
+    this.testStatusBar = new TestStatusBar({toggle: () => this.togglePanel()})
+    this.subscriptions.add(this.testStatusBar)
+
+    if (this.testStatusBarTile) {
+      this.testStatusBarTile.destroy()
+    }
+
+    this.testStatusBarTile = this.statusBar().addRightTile({
+      item: this.testStatusBar,
+      priority: 1000
+    })
+  }
+}
+export {TestPanelManager}

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -9,9 +9,10 @@ import rimraf from 'rimraf'
 import temp from 'temp'
 
 class Tester {
-  constructor (goconfigFunc, gogetFunc) {
+  constructor (goconfigFunc, gogetFunc, testPanelManagerFunc) {
     this.goget = gogetFunc
     this.goconfig = goconfigFunc
+    this.testPanelManager = testPanelManagerFunc
     this.subscriptions = new CompositeDisposable()
     this.saveSubscriptions = new CompositeDisposable()
     this.observeConfig()
@@ -41,6 +42,7 @@ class Tester {
     this.saveSubscriptions = null
     this.goget = null
     this.goconfig = null
+    this.testPanelManager = null
     this.running = null
   }
 
@@ -74,6 +76,9 @@ class Tester {
       if (runCoverageOnSave) {
         this.subscribeToSaveEvents()
       }
+    }))
+    this.subscriptions.add(atom.config.observe('tester-go.coverageHighlightMode', (coverageHighlightMode) => {
+      this.coverageHighlightMode = coverageHighlightMode
     }))
   }
 
@@ -147,6 +152,9 @@ class Tester {
     if (!this.ranges || this.ranges.length <= 0) {
       return
     }
+    if (this.coverageHighlightMode === 'disabled') {
+      return
+    }
 
     let editorRanges = _.filter(this.ranges, (r) => { return _.endsWith(file, r.file) })
 
@@ -160,9 +168,13 @@ class Tester {
       this.markedEditors.set(editor.id, coveredLayer.id + ',' + uncoveredLayer.id)
       for (let range of editorRanges) {
         if (range.count > 0) {
-          coveredLayer.markBufferRange(range.range, {invalidate: 'touch'})
+          if (this.coverageHighlightMode === 'covered-and-uncovered' || this.coverageHighlightMode === 'covered') {
+            coveredLayer.markBufferRange(range.range, {invalidate: 'touch'})
+          }
         } else {
-          uncoveredLayer.markBufferRange(range.range, {invalidate: 'touch'})
+          if (this.coverageHighlightMode === 'covered-and-uncovered' || this.coverageHighlightMode === 'uncovered') {
+            uncoveredLayer.markBufferRange(range.range, {invalidate: 'touch'})
+          }
         }
       }
       editor.decorateMarkerLayer(coveredLayer, {type: 'highlight', class: 'covered', onlyNonEmpty: true})
@@ -305,6 +317,7 @@ class Tester {
           args.push('-short')
         }
         let executorOptions = this.getExecutorOptions(editor)
+        this.testPanelManager().update({output: 'Running go ' + args.join(' '), state: 'pending'})
         return config.executor.exec(cmd, args, executorOptions).then((r) => {
           if (r.stderr && r.stderr.trim() !== '') {
             console.log('tester-go: (stderr) ' + r.stderr)
@@ -313,6 +326,9 @@ class Tester {
           if (r.exitcode === 0) {
             this.ranges = parser.ranges(this.coverageFile)
             this.addMarkersToEditors()
+            this.testPanelManager().update({exitcode: r.exitcode, output: r.stdout, state: 'success'})
+          } else {
+            this.testPanelManager().update({exitcode: r.exitcode, output: r.stdout, state: 'fail'})
           }
 
           this.running = false

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "coverage"
   ],
   "main": "./lib/main",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "repository": "https://github.com/joefitzgerald/tester-go",
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
   },
   "dependencies": {
     "atom-package-deps": "4.2.0",
+    "etch": "^0.6.3",
     "lodash": "^4.15.0",
     "temp": "^0.8.3",
     "rimraf": "^2.5.4"
   },
   "devDependencies": {
-    "standard": "^8.0.0-beta.4",
+    "standard": "^8.0.0",
     "fs-plus": "^2.8.1"
   },
   "package-deps": [
@@ -38,12 +39,17 @@
   "consumedServices": {
     "go-config": {
       "versions": {
-        "1.0.0": "consumeGoconfig"
+        "^1.0.0": "consumeGoconfig"
       }
     },
     "go-get": {
       "versions": {
-        "1.0.0": "consumeGoget"
+        "^1.0.0": "consumeGoget"
+      }
+    },
+    "status-bar": {
+      "versions": {
+        "^1.0.0": "consumeStatusBar"
       }
     }
   },
@@ -52,7 +58,7 @@
       "title": "Run Coverage Tool On Save",
       "description": "Run `go test -coverprofile` each time a file is saved",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "order": 1
     },
     "runCoverageWithShortFlag": {
@@ -61,6 +67,32 @@
       "type": "boolean",
       "default": true,
       "order": 2
+    },
+    "coverageHighlightMode": {
+      "title": "Coverage Highlight Mode",
+      "description": "Control the way that coverage highlighting occurs",
+      "type": "string",
+      "default": "uncovered",
+      "enum": [
+        "covered-and-uncovered",
+        "covered",
+        "uncovered",
+        "disabled"
+      ],
+      "order": 3
+    },
+    "displayTestOutputPanel": {
+      "title": "Display Test Output Panel",
+      "description": "When the test output panel is not being displayed, it will toggle on using this setting",
+      "type": "string",
+      "default": "always",
+      "enum": [
+        "always",
+        "success-only",
+        "failure-only",
+        "never"
+      ],
+      "order": 4
     }
   },
   "standard": {

--- a/spec/tester-spec.js
+++ b/spec/tester-spec.js
@@ -15,6 +15,7 @@ describe('tester', () => {
       if (process.env.GOPATH) {
         oldGopath = process.env.GOPATH
       }
+      atom.config.set('tester-go.coverageHighlightMode', 'covered-and-uncovered')
       gopath = temp.mkdirSync()
       process.env.GOPATH = gopath
       atom.project.setPaths(gopath)

--- a/styles/tester-go.less
+++ b/styles/tester-go.less
@@ -22,3 +22,34 @@
 .test-status-fail {
   color: @text-color-error;
 }
+
+
+// Panel --------------------
+
+.tester-go-panel {
+
+  .panel-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .panel-button {
+    color: inherit;
+    padding: 0;
+    border: none;
+    background-color: transparent;
+    cursor: default;
+
+    &:hover {
+      color: @text-color-highlight;
+    }
+    &:active {
+      color: @text-color-subtle;
+    }
+
+    &:before {
+      margin-right: 0;
+    }
+  }
+}

--- a/styles/tester-go.less
+++ b/styles/tester-go.less
@@ -1,0 +1,24 @@
+@import "ui-variables";
+
+.test-status-bar {
+  color: @text-color-success;
+  &:hover {
+    color: lighten(@text-color-success, 15%);
+  }
+}
+
+.test-status-unknown {
+  color: @text-color-info;
+}
+
+.test-status-pending {
+  color: @text-color-warning;
+}
+
+.test-status-success {
+  color: @text-color-success;
+}
+
+.test-status-fail {
+  color: @text-color-error;
+}

--- a/styles/tester-go.less
+++ b/styles/tester-go.less
@@ -34,6 +34,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    padding: @component-padding / 2;
   }
 
   .panel-button {
@@ -52,6 +53,29 @@
 
     &:before {
       margin-right: 0;
+    }
+  }
+
+  .panel-nav {
+    margin-bottom: -@component-padding/2 - 1px;
+  }
+  .panel-nav-item {
+    display: inline-block;
+    color: @text-color-subtle;
+    border: 1px solid transparent;
+    border-bottom: none;
+    padding: @component-padding/1.5 @component-padding;
+    cursor: default;
+
+    &:hover {
+      color: @text-color-highlight;
+    }
+    &:active,
+    &.is-selected {
+      color: @text-color-selected;
+      border-color: @panel-heading-border-color;
+      border-radius: @component-border-radius @component-border-radius 0 0;
+      background-color: @inset-panel-background-color;
     }
   }
 }


### PR DESCRIPTION
still needs “wiring up”.

![screen shot 2016-08-25 at 10 55 54 am](https://cloud.githubusercontent.com/assets/378023/17954023/0dd41d0a-6ab3-11e6-8346-eb0aad9848cb.png)

The tabs can be switched by moving the `.is-selected` class around. The content could be toggled by having those `<span>`s that aren't visible be `display: none`.