### PR TITLE
Feature gutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ time you save a `.go` file (default: `true`)
   * `uncovered`: highlight uncovered regions of text
   * `disabled`: disable highlighting
 * `useGutter`: Control the way code coverage is presented: (default: `false`)
-  * `false`: hilights affected lines
-  * `true`: uses line numbers gutter to highlight affected lines
+  * `false`: hilights the affected lines
+  * `true`: uses the line numbers gutter to denote affected lines
 * `focusPanelIfTestsFail`: If the `go-plus` panel is hidden, or the panel is showing a different tab, the panel will be expanded and the test tab focused when tests fail (default: `true`)

--- a/README.md
+++ b/README.md
@@ -24,4 +24,7 @@ time you save a `.go` file (default: `true`)
   * `covered`: highlight covered regions of text
   * `uncovered`: highlight uncovered regions of text
   * `disabled`: disable highlighting
+* `useGutter`: Control the way code coverage is presented: (default: `false`)
+  * `false`: hilights affected lines
+  * `true`: uses line numbers gutter to highlight affected lines
 * `focusPanelIfTestsFail`: If the `go-plus` panel is hidden, or the panel is showing a different tab, the panel will be expanded and the test tab focused when tests fail (default: `true`)

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -177,8 +177,10 @@ class Tester {
           }
         }
       }
-      editor.decorateMarkerLayer(coveredLayer, {type: 'highlight', class: 'covered', onlyNonEmpty: true})
-      editor.decorateMarkerLayer(uncoveredLayer, {type: 'highlight', class: 'uncovered', onlyNonEmpty: true})
+
+      let type = atom.config.get('tester-go.useGutter') ? 'line-number' : 'highlight';
+      editor.decorateMarkerLayer(coveredLayer, {type: type, class: 'covered', onlyNonEmpty: true})
+      editor.decorateMarkerLayer(uncoveredLayer, {type: type, class: 'uncovered', onlyNonEmpty: true})
     } catch (e) {
       console.log(e)
     }

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
       "order": 3
     },
     "useGutter": {
-      "title": "Show coverage in gutter",
-      "description": "use the gutter instead of highlighting",
+      "title": "Show Coverage In Gutter",
+      "description": "Uses the line numbers gutter to denote affected lines",
       "type": "boolean",
       "default": false,
       "order": 4

--- a/package.json
+++ b/package.json
@@ -84,12 +84,19 @@
       ],
       "order": 3
     },
+    "useGutter": {
+      "title": "Show coverage in gutter",
+      "description": "use the gutter instead of highlighting",
+      "type": "boolean",
+      "default": false,
+      "order": 4
+    },
     "focusPanelIfTestsFail": {
       "title": "Focus The go-plus Panel If Tests Fail",
       "description": "If the panel is hidden, or the panel is showing a different tab, the panel will be expanded and the test tab focused when tests fail.",
       "type": "boolean",
       "default": true,
-      "order": 4
+      "order": 5
     }
   },
   "standard": {

--- a/styles/tester-go.atom-text-editor.less
+++ b/styles/tester-go.atom-text-editor.less
@@ -9,3 +9,11 @@
   background-color: @background-color-success;
   opacity: 0.2;
 }
+
+.line-number.uncovered{
+  background-color: @background-color-error;
+}
+
+.line-number.covered{
+  background-color: @background-color-success;
+}


### PR DESCRIPTION
I'm unsure if this is something you're interested in, or others. But a colleague and I find this mode less distracting. 

Here is a sample

![image](https://cloud.githubusercontent.com/assets/957896/21277825/32b9d528-c3a6-11e6-81e6-7b0ae2d84d07.png)

There is one thing to note, a trade off I suppose. Because you can technically have covered and uncovered code on the same line, it will show up as covered. But so far, it's usually happened in an if block, where the code inside shows up as uncovered anyway. 